### PR TITLE
video: Add support for EDID

### DIFF
--- a/linuxpy/ctypes.py
+++ b/linuxpy/ctypes.py
@@ -43,6 +43,7 @@ cast = ctypes.cast
 sizeof = ctypes.sizeof
 byref = ctypes.byref
 addressof = ctypes.addressof
+string_at = ctypes.string_at
 
 calcsize = struct.calcsize
 


### PR DESCRIPTION
Add high level API to set and get EDID. This is useful for devices that are display-like and are able to mimic multiple EDIDs.