### PR TITLE
pixel formats are case sensistive

### DIFF
--- a/linuxpy/video/device.py
+++ b/linuxpy/video/device.py
@@ -443,7 +443,7 @@ def set_raw_format(fd, fmt: raw.v4l2_format):
 def set_format(fd, buffer_type: BufferType, width: int, height: int, pixel_format: str = "MJPG"):
     fmt = raw.v4l2_format()
     if isinstance(pixel_format, str):
-        pixel_format = raw.v4l2_fourcc(*pixel_format.upper())
+        pixel_format = raw.v4l2_fourcc(*pixel_format)
     fmt.type = buffer_type
     fmt.fmt.pix.pixelformat = pixel_format
     fmt.fmt.pix.field = Field.ANY

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -119,6 +119,8 @@ class Hardware:
 
     def ioctl(self, fd, ioc, arg):  # noqa: C901
         # assert self.fd == fd
+        self.ioctl_ioc = ioc
+        self.ioctl_arg = arg
         if isinstance(arg, raw.v4l2_input):
             if arg.index > 0:
                 raise OSError(EINVAL, "ups!")
@@ -340,6 +342,17 @@ def _(camera=hardware):
     assert device.info.bus_info == camera.bus_info.decode()
     assert device.info.bus_info == camera.bus_info.decode()
     assert device.info.version == camera.version_str
+
+
+@test("set format")
+def _(camera=hardware):
+    device = Device(camera.filename)
+    with device:
+        device.set_format(BufferType.VIDEO_CAPTURE, 7, 5, 'pRCC')
+    assert camera.ioctl_ioc == raw.IOC.S_FMT
+    assert camera.ioctl_arg.fmt.pix.height == 5
+    assert camera.ioctl_arg.fmt.pix.width == 7
+    assert camera.ioctl_arg.fmt.pix.pixelformat == PixelFormat.SRGGB12P
 
 
 @test("controls")


### PR DESCRIPTION
the v4l2 pixel format specifier is case sensitive, using `upper` on it is a bad idea. 'pRCC' is something different than 'PRCC'.