### PR TITLE
Fix likely REQBUFS failure when memory still mapped

### DIFF
--- a/linuxpy/video/device.py
+++ b/linuxpy/video/device.py
@@ -1847,8 +1847,10 @@ class MemorySource(ReentrantOpen):
 
     def release_buffers(self):
         self.device.log.info("Freeing buffers...")
-        self.buffer_manager.free_buffers(self.source)
+        for buf in self.buffers:
+            buf.close()
         self.buffers = None
+        self.buffer_manager.free_buffers(self.source)
         self.format = None
         self.device.log.info("Buffers freed")
 


### PR DESCRIPTION
According to [7.52 ioctl - VIDIOC_REQBUFS](https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/vidioc-reqbufs.html#vidioc-reqbufs):

> Applications can call [ioctl VIDIOC_REQBUFS](https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/vidioc-reqbufs.html#vidioc-reqbufs) again to change the number of buffers. Note that if any buffers are still mapped or exported via DMABUF, then [ioctl VIDIOC_REQBUFS](https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/vidioc-reqbufs.html#vidioc-reqbufs) can only succeed if the V4L2_BUF_CAP_SUPPORTS_ORPHANED_BUFS capability is set. Otherwise [ioctl VIDIOC_REQBUFS](https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/vidioc-reqbufs.html#vidioc-reqbufs) will return the EBUSY error code.

Because many devices, e.g. v4l2loopback in particular, don't support `V4L2_BUF_CAP_SUPPORTS_ORPHANED_BUFS` it's better to ensure that the mmap buffers are closed before invoking `VIDIOC_REQBUF`.

This PR should correctly call `munmap()` first if using cpython. I haven't tested with other python implementations.

Side note: v4l2loopback (in particular 0.13.x) has issues with denying REQBUFS even when it shouldn't - I'm just now working on a fix for that, too (see https://github.com/umlaeute/v4l2loopback/pull/599).

