### PR TITLE
Add keys and __contains__ method to Controls class

### DIFF
--- a/linuxpy/video/device.py
+++ b/linuxpy/video/device.py
@@ -1108,6 +1108,10 @@ class Controls(dict):
         self._init_if_needed()
         return super().items()
 
+    def keys(self):
+        self._init_if_needed()
+        return super().keys()
+    
     def values(self):
         self._init_if_needed()
         return super().values()

--- a/linuxpy/video/device.py
+++ b/linuxpy/video/device.py
@@ -1104,6 +1104,10 @@ class Controls(dict):
                 return v
         raise KeyError(key)
 
+    def __contains__(self, key):
+        self._init_if_needed()
+        return super().__contains__(key)
+
     def items(self):
         self._init_if_needed()
         return super().items()


### PR DESCRIPTION
The `Control` class (video) inherits from `dict` but only overrides `items()` and `values()`, leaving `keys()` and the `in` keyword to fall back to the default `dict` implementation. This causes those methods to return an empty result immediately after device creation, before any refresh has occurred.

As a result, membership checks like:

```python
ControlsID.FOCUS_AUTO in cam.controls
```

…silently fail unless `controls.refresh()` is explicitly called.